### PR TITLE
fetch polyfill for safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-router": "2.8.1",
     "react-s-alert": "1.2.2",
     "sqlite3": "^3.1.4",
-    "webpack": "1.13.2"
+    "webpack": "1.13.2",
+    "whatwg-fetch": "^2.0.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ var BUILD_DIR = path.resolve(__dirname, 'client/public');
 var APP_DIR = path.resolve(__dirname, 'client/app');
 
 var config = {
-  entry: APP_DIR + '/index.jsx',
+  entry: ['whatwg-fetch', APP_DIR + '/index.jsx'],
   output: {
     path: BUILD_DIR,
     filename: 'bundle.js'


### PR DESCRIPTION
Here's a fix to make Matterwiki work with Safari... Safari doesn't have the fetch API and needs a polyfill